### PR TITLE
Add Docker image (#6)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  web:
+    build: .
+    ports:
+      - "80:80"
+    volumes:
+      - .:/app
+    environment:
+      NODE_ENV: development

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-alpine
+WORKDIR /app
+
+COPY . .
+
+RUN npm install
+RUN npm install -g http-server
+
+EXPOSE 80
+
+CMD ["http-server", "-p", "80"]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "font-compare",
+  "version": "1.0.0",
+  "description": "Font Compare Application",
+  "main": "index.html",
+  "scripts": {
+    "start": "npx http-server -p 80"
+  },
+  "dependencies": {
+    "http-server": "^0.12.3"
+  }
+}


### PR DESCRIPTION
closes #6 

- Added a Dockerfile to containerize fontcompare.
- Set the base image to node:18-alpine for a lightweight Node.js environment.
- Set the default command to run http-server on port 80.


This setup allows for easy development and testing of the web service using Docker Compose.

## How to Build and Run with Docker Compose
   Open a terminal in the directory containing the `docker-compose.yml` file and run the following command:

   ```sh
   docker-compose build
   docker-compose up
```

## Results
![2024-11-21](https://github.com/user-attachments/assets/dd1f1125-060a-4bfb-a25d-55545f0f75d7)
![2024-11-21 (1)](https://github.com/user-attachments/assets/3063bda1-5364-4b87-9e80-8234393559c8)
