### PR TITLE
add default values and labels to color picker

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -16,32 +16,44 @@ body {
     position: relative;
 }
 
-#backgroundColorPicker {
-    width: 40px;
-    height: 40px;
-    cursor: pointer;
-    border: none;
-    padding: 0;
+#colorPickers {
     position: fixed; 
     top: 20px; 
     right: 20px;
     z-index: 1000;
     background-color: transparent;
+    display:flex;
+    flex-direction: column;
 }
 
-#fontColorPicker {
-    width: 40px;
+#colorPickers > div {
+    display: flex;
+    justify-content: space-between; 
+}
+
+#colorPickers label {
+	align-content: center;
+	margin-right: 0.3rem;	
+	margin-left: auto;	
+	overflow: visible;
+	text-wrap: nowrap;
+	opacity: 0;
+	transform: translateX(0);
+	transition: opacity .7s ease, transform .7s ease; 
+}
+
+.color-pickers {
+	flex:0 0 40px;
     height: 40px;
     cursor: pointer;
     border: none;
     padding: 0;
-    position: fixed;
-    top: 60px;
-    right: 20px;
-    z-index: 1000;
-    background-color: transparent;
 }
 
+#colorPickers:has(.color-pickers:hover) label, #colorPickers:has(.color-pickers:focus) label {
+	opacity: 1;
+	transform: translateX(-1.5rem);
+}
 
 .dragging-over {
     border: 2px dashed #fff;
@@ -63,7 +75,6 @@ body {
     font-size: 2em;
     z-index: 1000;
 }
-
 
 .logo {
     max-width: 500px;
@@ -152,7 +163,6 @@ body {
     gap: 10px; 
     justify-content: flex-start;
 }
-
 
 #fontParams.show {
     display: flex;

--- a/index.html
+++ b/index.html
@@ -38,9 +38,16 @@
     <div id="fontSamples">
     </div>
 
-
-    <input type="color" id="backgroundColorPicker" />
-    <input type="color" id="fontColorPicker" />
+	<div id="colorPickers">
+		<div>
+			<label for="backgroundColorPicker" class="lineUp">Background color</label>
+				<input type="color" id="backgroundColorPicker" class="color-pickers" value="#cccccc" autocomplete="off"/>
+		</div>
+		<div>
+			<label for="fontColorPicker">Font color</label>
+			<input type="color" id="fontColorPicker" class="color-pickers" value="#000000" autocomplete="off"/>
+		</div>
+	</div>
 
     <script src="js/script.js"></script>
 </body>


### PR DESCRIPTION
PR content:
1. add default values for color pickers (currently at page load there is mismatch between color pickers' color and actual background and font colors). 
    -  TODO: yet to adapt for dark theme  
2. add labels for color pickers